### PR TITLE
Update download url template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ dmypy.json
 
 # VS Code Settings
 .vscode
+
+# IntelliJ Settings
+.idea

--- a/comcrawl/utils/download.py
+++ b/comcrawl/utils/download.py
@@ -12,7 +12,7 @@ from ..types import Result, ResultList
 from .multithreading import make_multithreaded
 
 
-URL_TEMPLATE = "https://commoncrawl.s3.amazonaws.com/{filename}"
+URL_TEMPLATE = "https://data.commoncrawl.org/{filename}"
 
 
 def download_single_result(result: Result) -> Result:

--- a/tests/comcrawl/utils/snapshots/snap_test_search.py
+++ b/tests/comcrawl/utils/snapshots/snap_test_search.py
@@ -7,7 +7,7 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_search_single_index 1'] = [{'charset': 'UTF-8',
+snapshots['test_search_single_index 1'] = [{'encoding': 'UTF-8',
                                             'digest': '745JGUNVPWB4L3TWJIGUQRQFTFSREJ5J',
                                             'filename': 'crawl-data/CC-MAIN-2019-51/segments/1575540500637.40/warc/CC-MAIN-20191207160050-20191207184050-00394.warc.gz',
                                             'languages': 'eng',
@@ -42,7 +42,7 @@ snapshots['test_search_single_index 1'] = [{'charset': 'UTF-8',
 
 snapshots['test_search_multiple_indexes_single_threaded 1'] = [
     {
-        'charset': 'UTF-8',
+        'encoding': 'UTF-8',
         'digest': '745JGUNVPWB4L3TWJIGUQRQFTFSREJ5J',
         'filename': 'crawl-data/CC-MAIN-2019-51/segments/1575540500637.40/warc/CC-MAIN-20191207160050-20191207184050-00394.warc.gz',
         'languages': 'eng',
@@ -56,7 +56,7 @@ snapshots['test_search_multiple_indexes_single_threaded 1'] = [
         'urlkey': 'org,commoncrawl,index)/'
     },
     {
-        'charset': 'UTF-8',
+        'encoding': 'UTF-8',
         'digest': 'SVH4V5QDUS7SMXSXZYB2XWJSVDWFXUD7',
         'filename': 'crawl-data/CC-MAIN-2019-47/segments/1573496667767.6/warc/CC-MAIN-20191114002636-20191114030636-00394.warc.gz',
         'languages': 'eng',
@@ -73,7 +73,7 @@ snapshots['test_search_multiple_indexes_single_threaded 1'] = [
 
 snapshots['test_search_multiple_indexes_multi_threaded 1'] = [
     {
-        'charset': 'UTF-8',
+        'encoding': 'UTF-8',
         'digest': 'SVH4V5QDUS7SMXSXZYB2XWJSVDWFXUD7',
         'filename': 'crawl-data/CC-MAIN-2019-47/segments/1573496667767.6/warc/CC-MAIN-20191114002636-20191114030636-00394.warc.gz',
         'languages': 'eng',
@@ -87,7 +87,7 @@ snapshots['test_search_multiple_indexes_multi_threaded 1'] = [
         'urlkey': 'org,commoncrawl,index)/'
     },
     {
-        'charset': 'UTF-8',
+        'encoding': 'UTF-8',
         'digest': '745JGUNVPWB4L3TWJIGUQRQFTFSREJ5J',
         'filename': 'crawl-data/CC-MAIN-2019-51/segments/1575540500637.40/warc/CC-MAIN-20191207160050-20191207184050-00394.warc.gz',
         'languages': 'eng',

--- a/tests/snapshots/snap_test_comcrawl.py
+++ b/tests/snapshots/snap_test_comcrawl.py
@@ -8,7 +8,7 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots['test_comcrawl 1'] = {
-    'charset': 'UTF-8', 'digest': '745JGUNVPWB4L3TWJIGUQRQFTFSREJ5J', 'filename': 'crawl-data/CC-MAIN-2019-51/segments/1575540500637.40/warc/CC-MAIN-20191207160050-20191207184050-00394.warc.gz', 'html': '''<!DOCTYPE html>
+    'encoding': 'UTF-8', 'digest': '745JGUNVPWB4L3TWJIGUQRQFTFSREJ5J', 'filename': 'crawl-data/CC-MAIN-2019-51/segments/1575540500637.40/warc/CC-MAIN-20191207160050-20191207184050-00394.warc.gz', 'html': '''<!DOCTYPE html>
 <html>
 <head>
 <link rel="stylesheet" href="/static/__shared/shared.css"/>


### PR DESCRIPTION
Recently Common Crawl base URL was changed to "https://data.commoncrawl.org/" (see [blog post](https://commoncrawl.org/2022/03/introducing-cloudfront-access-to-common-crawl-data/)), which caused issues when downloading pages (fixes #40).

Also, it seems that some time ago 'charset' attribute was renamed to 'encoding'.