### PR TITLE
AWS changed their WARC file base recently

### DIFF
--- a/comcrawl/utils/download.py
+++ b/comcrawl/utils/download.py
@@ -12,7 +12,8 @@ from ..types import Result, ResultList
 from .multithreading import make_multithreaded
 
 
-URL_TEMPLATE = "https://commoncrawl.s3.amazonaws.com/{filename}"
+# URL_TEMPLATE = "https://commoncrawl.s3.amazonaws.com/{filename}"
+URL_TEMPLATE = "https://data.commoncrawl.org/{filename}"
 
 
 def download_single_result(result: Result) -> Result:


### PR DESCRIPTION
AWS recently changed their base S3 path from https://commoncrawl.s3.amazonaws.com to https://data.commoncrawl.org
I made a simple update to the download template to fix this.
-Bill Roe