### PR TITLE
Update common crawl download url

### DIFF
--- a/comcrawl/utils/download.py
+++ b/comcrawl/utils/download.py
@@ -12,7 +12,7 @@ from ..types import Result, ResultList
 from .multithreading import make_multithreaded
 
 
-URL_TEMPLATE = "https://commoncrawl.s3.amazonaws.com/{filename}"
+URL_TEMPLATE = "https://data.commoncrawl.org/{filename}"
 
 
 def download_single_result(result: Result) -> Result:


### PR DESCRIPTION
The previous URL was not working anymore, instead returning a 403 status code. Fixed the URL conform https://commoncrawl.org/access-the-data/.